### PR TITLE
🕷 bug fix consecutive comments

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,12 @@
 
 All notable changes to the "eslint-plugin-avoid-comments" extension will be documented in this file.
 
+## [0.0.2] - 2024-04-02
+
+### Changed
+
+- Fix bug that made the rule doesn't identify consecutive comments (it shouldn't report consecutive comments if the first one is allowed). The rule won't consider blank lines between consecutive comments.
+
 ## [0.0.1] - 2024-04-02
 
 ### Changed

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # ✨ eslint-plugin-avoid-comments
 
-Some comments cause unnecessary noise in the code, so this rule makes ESLint disallow comments that do not fit the proposals of pre-configured **keywords**.
+Some comments cause unnecessary noise in the code, so this rule makes ESLint disallow comments that do not fit the proposals of pre-configured **prefixes keywords**.
 
 ## Installation
 

--- a/avoid-comments-rule.js
+++ b/avoid-comments-rule.js
@@ -14,11 +14,9 @@ module.exports = {
       const previousTokenOrComment = sourceCode.getTokenBefore(comment, {
         includeComments: true,
       });
-      const isLineBeforeEmpty = sourceCode.getText(comment, 2)[0].trim() === "";
 
       return (
         previousTokenOrComment &&
-        !isLineBeforeEmpty &&
         ["Block", "Line"].includes(previousTokenOrComment.type)
       );
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-avoid-comments",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ESLint customized rule to prevent comments",
   "main": "avoid-comments-plugin",
   "repository": {
@@ -22,6 +22,14 @@
   "keywords": [
     "eslint",
     "eslintplugin",
-    "eslint-plugin"
+    "eslint-plugin",
+    "comment",
+    "comments",
+    "eslint-disable",
+    "eslint-disable-line",
+    "keywords",
+    "keyword",
+    "prefixes",
+    "prefix"
   ]
 }


### PR DESCRIPTION
Fix bug that made the rule doesn't identify consecutive comments (it shouldn't report consecutive comments if the first one is allowed). The rule won't consider blank lines between consecutive comments.